### PR TITLE
Use standard line ending in examples

### DIFF
--- a/examples/Projects/SpinAWheel/spinAWheel_Stage1/spinAWheel_Stage1.ino
+++ b/examples/Projects/SpinAWheel/spinAWheel_Stage1/spinAWheel_Stage1.ino
@@ -1,1 +1,39 @@
-/*  CTC GO! MOTION   PROJECT - Spin-A-Wheel  This sketch is written to accompany Stage 1 of the Spin-a-Wheel project*/int button_1 = 2;int button_2 = 3;int buttonState_1;int buttonState_2;void setup() {  ______(button_1, ______);______(button_2, ______);Serial.begin(9600);}void loop() {buttonState_1 = ______(button_1);buttonState_2 = ______(button_2);if(____________ == HIGH) {  Serial.println("Button 1 pressed");  delay(1000);}if(____________ == HIGH) {  Serial.println("Button 2 pressed");  delay(1000);}delay(100);}
+/*
+  CTC GO! MOTION 
+  PROJECT - Spin-A-Wheel
+
+  This sketch is written to accompany Stage 1 of the Spin-a-Wheel project
+*/
+
+int button_1 = 2;
+int button_2 = 3;
+
+int buttonState_1;
+int buttonState_2;
+
+void setup() {
+  
+______(button_1, ______);
+______(button_2, ______);
+Serial.begin(9600);
+
+}
+
+void loop() {
+
+buttonState_1 = ______(button_1);
+buttonState_2 = ______(button_2);
+
+if(____________ == HIGH) {
+  Serial.println("Button 1 pressed");
+  delay(1000);
+}
+
+if(____________ == HIGH) {
+  Serial.println("Button 2 pressed");
+  delay(1000);
+}
+
+delay(100);
+}
+

--- a/examples/Projects/WaveGenerator/waveGenerator_Stage1/waveGenerator_Stage1.ino
+++ b/examples/Projects/WaveGenerator/waveGenerator_Stage1/waveGenerator_Stage1.ino
@@ -1,1 +1,33 @@
-/*  CTC GO! MOTION   PROJECT - Wave Generator  This sketch is written to accompany Stage 1 of the Wave Generator project*/int potPin = A0;int lightSensor = A1;int lightValue = 0;int potValue = 0;void setup() {    ______(9600); }void loop() {    _____ = analogRead(_____);  Serial._____("Light Value: ");  Serial.println(_____);    delay(20);    _____ = analogRead(____);  Serial._____("Pot Value: ");  Serial.println(_____);  delay(20);   Serial.println(" ");  delay(250); }
+/*
+  CTC GO! MOTION 
+  PROJECT - Wave Generator
+
+  This sketch is written to accompany Stage 1 of the Wave Generator project
+*/
+
+int potPin = A0;
+int lightSensor = A1;
+
+int lightValue = 0;
+int potValue = 0;
+
+void setup() {  
+  ______(9600); 
+}
+
+void loop() {  
+  _____ = analogRead(_____);
+  Serial._____("Light Value: ");
+  Serial.println(_____);  
+  delay(20);
+  
+  _____ = analogRead(____);
+  Serial._____("Pot Value: ");
+  Serial.println(_____);
+  delay(20);
+ 
+  Serial.println(" ");
+  delay(250); 
+}
+
+

--- a/examples/Projects/WaveGenerator/waveGenerator_Stage2/waveGenerator_Stage2.ino
+++ b/examples/Projects/WaveGenerator/waveGenerator_Stage2/waveGenerator_Stage2.ino
@@ -1,1 +1,50 @@
-/*  CTC GO! MOTION   PROJECT - Wave Generator  This sketch is written to accompany Stage 2 of the Wave Generator project*/#include <Servo.h>_____ servo_rotate;_____ servo_arm;int lightSensor = A1;int potPin = A0;int lightValue = 0;int potValue = 0;int new_potValue;int new_lightValue;void setup(){    servo_rotate._____(6);  servo_arm._____(9);  Serial.begin(9600);}void loop() {    lightValue = analogRead(lightSensor);  Serial.print("Light Value: ");  Serial.println(lightValue);    new_lightValue = map(lightValue, 100, 900, ____, _____);  servo_arm.____(____);  delay(20);    potValue = analogRead(potPin);  Serial.print("Pot Value: ");   Serial.println(potValue);  new_potValue = map(potValue, 0, 1023, ____, ____);  servo_rotate._____(____);  delay(20);    Serial.println("");  //delay(250);  }
+/*
+  CTC GO! MOTION 
+  PROJECT - Wave Generator
+
+  This sketch is written to accompany Stage 2 of the Wave Generator project
+*/
+
+
+#include <Servo.h>
+
+_____ servo_rotate;
+_____ servo_arm;
+
+int lightSensor = A1;
+int potPin = A0;
+
+int lightValue = 0;
+int potValue = 0;
+
+int new_potValue;
+int new_lightValue;
+
+void setup(){
+  
+  servo_rotate._____(6);
+  servo_arm._____(9);
+  Serial.begin(9600);
+}
+
+void loop() 
+{
+  
+  lightValue = analogRead(lightSensor);
+  Serial.print("Light Value: ");
+  Serial.println(lightValue);  
+  new_lightValue = map(lightValue, 100, 900, ____, _____);
+  servo_arm.____(____);
+  delay(20);
+  
+  potValue = analogRead(potPin);
+  Serial.print("Pot Value: "); 
+  Serial.println(potValue);
+  new_potValue = map(potValue, 0, 1023, ____, ____);
+  servo_rotate._____(____);
+  delay(20);
+  
+  Serial.println("");
+  //delay(250);
+  
+}

--- a/examples/Projects/WaveGenerator/waveGenerator_Stage3/waveGenerator_Stage3.ino
+++ b/examples/Projects/WaveGenerator/waveGenerator_Stage3/waveGenerator_Stage3.ino
@@ -1,1 +1,86 @@
-/*  CTC GO! MOTION   PROJECT - Wave Generator  This sketch is written to accompany Stage 3 of the Wave Generator project*/#include <Servo.h>Servo servo_rotate;Servo servo_arm;int button = 2;int lightSensor = A1;int potPin = A0;int lightValue = 0;int potValue = 0;int new_potValue;int new_lightValue;int buttonState = LOW;_____ previousState = LOW;_____ isButtonPressed = false;int modeCounter = 1;void setup(){    pinMode(button, _____);  servo_rotate.attach(6);  servo_arm.attach(9);  Serial.begin(9600);}void loop() {    potValue = analogRead(potPin);  Serial.println(potValue);  new_potValue = map(potValue, 100, 900, 0, 180);  servo_rotate.write(new_potValue);  delay(20);    lightValue = analogRead(lightSensor);  Serial.println(lightValue);    new_lightValue = map(lightValue, 0, 1023, 0, 180);  servo_arm.write(new_lightValue);  delay(20);    Serial.println("");  //delay(250);    buttonState = digitalRead(_____);  if (prevButtonState != buttonState)  {     isButtonPressed = buttonState;  }       if (isButtonPressed == true)  {    updateModeCounter();    isButtonPressed = false;  }    prevButtonState = buttonState;  }void updateModeCounter(){    if(modeCounter < 2)    {      modeCounter ++ ;      Serial.println("Counter value : ");      Serial.println(modeCounter);    }    else    {      modeCounter = 1 ;        Serial.println("Counter value: ");      Serial.println(modeCounter);    }}
+/*
+  CTC GO! MOTION 
+  PROJECT - Wave Generator
+
+  This sketch is written to accompany Stage 3 of the Wave Generator project
+*/
+
+
+#include <Servo.h>
+
+Servo servo_rotate;
+Servo servo_arm;
+
+int button = 2;
+int lightSensor = A1;
+int potPin = A0;
+
+int lightValue = 0;
+int potValue = 0;
+
+int new_potValue;
+int new_lightValue;
+
+int buttonState = LOW;
+_____ previousState = LOW;
+_____ isButtonPressed = false;
+
+int modeCounter = 1;
+
+void setup()
+{  
+  pinMode(button, _____);
+  servo_rotate.attach(6);
+  servo_arm.attach(9);
+  Serial.begin(9600);
+}
+
+void loop() {
+  
+  potValue = analogRead(potPin);
+  Serial.println(potValue);
+  new_potValue = map(potValue, 100, 900, 0, 180);
+  servo_rotate.write(new_potValue);
+  delay(20);
+  
+  lightValue = analogRead(lightSensor);
+  Serial.println(lightValue);  
+  new_lightValue = map(lightValue, 0, 1023, 0, 180);
+  servo_arm.write(new_lightValue);
+  delay(20);
+  
+  Serial.println("");
+  //delay(250);
+  
+  buttonState = digitalRead(_____);
+  if (prevButtonState != buttonState)
+  { 
+    isButtonPressed = buttonState;
+  } 
+    
+  if (isButtonPressed == true)
+  {
+    updateModeCounter();
+    isButtonPressed = false;
+  }
+  
+  prevButtonState = buttonState;
+  
+}
+
+void updateModeCounter()
+{
+    if(modeCounter < 2)
+    {
+      modeCounter ++ ;
+      Serial.println("Counter value : ");
+      Serial.println(modeCounter);
+    }
+    else
+    {
+      modeCounter = 1 ;  
+      Serial.println("Counter value: ");
+      Serial.println(modeCounter);
+    }
+}
+

--- a/examples/Projects/WaveGenerator/waveGenerator_Stage5/waveGenerator_Stage5.ino
+++ b/examples/Projects/WaveGenerator/waveGenerator_Stage5/waveGenerator_Stage5.ino
@@ -1,1 +1,112 @@
-/*  CTC GO! MOTION   PROJECT - Wave Generator  This sketch is written to accompany Stage 5 of the Wave Generator project*/#include <Servo.h>Servo servo_rotate;Servo servo_arm;int button = 2;int potPin = A0;int lightSensor = A1;int potValue = 0;int lightValue = 0;int new_potValue;int new_lightValue;int timing_lightValue;int buttonState = LOW;int isButtonPressed = LOW;boolean isButtonPressed = false;int modeCounter = 1;void setup(){  pinMode(button, INPUT);  servo_rotate.attach(6);  servo_arm.attach(9);  Serial.begin(9600);}void loop() {    potValue = analogRead(potPin);  Serial.println(potValue);  new_potValue = map(potValue, 0, 1023, 0, 180);  servo_rotate.write(new_potValue);  delay(20);    lightValue = analogRead(lightSensor);  Serial.println(lightValue);    // new_lightValue = map(lightValue, 100, 900, 0, 180);  // servo_arm.write(new_lightValue);  // delay(20);     Serial.println("");  //delay(250);     buttonState = digitalRead(button);   if (prevButtonState != buttonState)  {     isButtonPressed = buttonState;  }       if (isButtonPressed == true)  {     updateModeCounter();     isButtonPressed = false;  }    prevButtonState = buttonState;      switch(_____)  {    case 1:    Serial.println("mode 1");    _____;    break;        case 2:    Serial.println("mode 2");    _____;    break;  }  }void updateModeCounter(){    if(modeCounter < 2)    {      modeCounter ++ ;    }    else    {      modeCounter = 1 ;      }}void modeOne(){  new_lightValue = map(lightValue, 100, 900, 0, 180);  servo_arm.write(new_lightValue);  delay(20);   }void modeTwo(){  timing_lightValue = map(_____, 100, 900, 0, 500);  servo_arm.write(10);  delay(_____);  servo_arm.write(70);  delay(____);}
+/*
+  CTC GO! MOTION 
+  PROJECT - Wave Generator
+
+  This sketch is written to accompany Stage 5 of the Wave Generator project
+*/
+
+#include <Servo.h>
+
+Servo servo_rotate;
+Servo servo_arm;
+
+int button = 2;
+int potPin = A0;
+int lightSensor = A1;
+
+int potValue = 0;
+int lightValue = 0;
+
+int new_potValue;
+int new_lightValue;
+int timing_lightValue;
+
+int buttonState = LOW;
+int isButtonPressed = LOW;
+boolean isButtonPressed = false;
+
+int modeCounter = 1;
+
+void setup()
+{
+  pinMode(button, INPUT);
+  servo_rotate.attach(6);
+  servo_arm.attach(9);
+  Serial.begin(9600);
+}
+
+void loop() 
+{
+  
+  potValue = analogRead(potPin);
+  Serial.println(potValue);
+  new_potValue = map(potValue, 0, 1023, 0, 180);
+  servo_rotate.write(new_potValue);
+  delay(20);
+  
+  lightValue = analogRead(lightSensor);
+  Serial.println(lightValue);  
+  // new_lightValue = map(lightValue, 100, 900, 0, 180);
+  // servo_arm.write(new_lightValue);
+  // delay(20); 
+  
+  Serial.println("");
+  //delay(250);
+  
+   buttonState = digitalRead(button); 
+  if (prevButtonState != buttonState)
+  { 
+    isButtonPressed = buttonState;
+  } 
+    
+  if (isButtonPressed == true)
+  {
+     updateModeCounter();
+     isButtonPressed = false;
+  }
+  
+  prevButtonState = buttonState;  
+  
+  switch(_____)
+  {
+    case 1:
+    Serial.println("mode 1");
+    _____;
+    break;
+    
+    case 2:
+    Serial.println("mode 2");
+    _____;
+    break;
+  }
+  
+}
+
+void updateModeCounter()
+{
+    if(modeCounter < 2)
+    {
+      modeCounter ++ ;
+    }
+    else
+    {
+      modeCounter = 1 ;  
+    }
+}
+
+void modeOne()
+{
+  new_lightValue = map(lightValue, 100, 900, 0, 180);
+  servo_arm.write(new_lightValue);
+  delay(20);   
+}
+
+void modeTwo()
+{
+  timing_lightValue = map(_____, 100, 900, 0, 500);
+  servo_arm.write(10);
+  delay(_____);
+  servo_arm.write(70);
+  delay(____);
+}
+

--- a/examples/Projects/Wiggler/Wiggler_Stage1/Wiggler_Stage1.ino
+++ b/examples/Projects/Wiggler/Wiggler_Stage1/Wiggler_Stage1.ino
@@ -1,1 +1,31 @@
-/*  CTC GO! MOTION   PROJECT - Wiggler  This sketch is written to accompany Stage 1 of the Wiggler project*/int lightSensor_1 = A0;int lightSensor_2 = A1;int lightValue_1 = 0;int lightValue_2 = 0;void setup() {Serial.begin(9600);}void loop() {    lightValue_1 = ______(______);  lightValue_2 = ______(______);  Serial.print("First Light Value: ");  Serial.println(______);  Serial.print("Second Light Value: ");  Serial.println(______);  delay(1000);}
+/*
+  CTC GO! MOTION 
+  PROJECT - Wiggler
+
+  This sketch is written to accompany Stage 1 of the Wiggler project
+*/
+
+int lightSensor_1 = A0;
+int lightSensor_2 = A1;
+
+int lightValue_1 = 0;
+int lightValue_2 = 0;
+
+void setup() {
+Serial.begin(9600);
+}
+
+
+void loop() {
+  
+  lightValue_1 = ______(______);
+  lightValue_2 = ______(______);
+
+  Serial.print("First Light Value: ");
+  Serial.println(______);
+  Serial.print("Second Light Value: ");
+  Serial.println(______);
+  delay(1000);
+}
+
+

--- a/examples/Projects/Wiggler/Wiggler_Stage2/Wiggler_Stage2.ino
+++ b/examples/Projects/Wiggler/Wiggler_Stage2/Wiggler_Stage2.ino
@@ -1,1 +1,45 @@
-/*  CTC GO! MOTION   PROJECT - Wiggler  This sketch is written to accompany Stage 2 of the Wiggler project*/#include <Servo.h>Servo servo_drive;Servo servo_steer;int lightSensor_1 = A0;int lightSensor_2 = A1;int lightValue_1 = 0;int lightValue_2 = 0;void setup(){servo_steer.______(6);servo_drive.____(9);Serial.begin(9600);}void loop() {  lightValue_1 = analogRead(lightSensor_1);  lightValue_2 = analogRead(lightSensor_2);  Serial.print("First Light Value: ");  Serial.println(lightValue_1);  Serial.print("Second Light Value: ");  Serial.println(lightValue_2);  servo_drive.______(120);  servo_steer.______(30);  delay(500);  servo_steer.______(150);  delay(500);}
+/*
+  CTC GO! MOTION 
+  PROJECT - Wiggler
+
+  This sketch is written to accompany Stage 2 of the Wiggler project
+*/
+
+
+#include <Servo.h>
+
+Servo servo_drive;
+Servo servo_steer;
+
+int lightSensor_1 = A0;
+int lightSensor_2 = A1;
+
+int lightValue_1 = 0;
+int lightValue_2 = 0;
+
+void setup()
+{
+servo_steer.______(6);
+servo_drive.____(9);
+Serial.begin(9600);
+}
+
+
+void loop() 
+{
+  lightValue_1 = analogRead(lightSensor_1);
+  lightValue_2 = analogRead(lightSensor_2);
+
+  Serial.print("First Light Value: ");
+  Serial.println(lightValue_1);
+  Serial.print("Second Light Value: ");
+  Serial.println(lightValue_2);
+
+
+  servo_drive.______(120);
+  servo_steer.______(30);
+  delay(500);
+  servo_steer.______(150);
+  delay(500);
+}
+

--- a/examples/Projects/Wiggler/Wiggler_Stage5/Wiggler_Stage5.ino
+++ b/examples/Projects/Wiggler/Wiggler_Stage5/Wiggler_Stage5.ino
@@ -1,1 +1,79 @@
-/*  CTC GO! MOTION   PROJECT - Wiggler  This sketch is written to accompany Stage 5 of the Wiggler project*/#include <Servo.h>Servo servo_drive;Servo servo_steer;int lightSensor_1 = A0;int lightSensor_2 = A1;int lightValue_1 = 0;int lightValue_2 = 0;int ______ = 30;int ______ = 150;void setup() {    servo_steer.attach(6);  servo_drive.attach(9);  Serial.begin(9600);}void loop() {  lightValue_1 = analogRead(lightSensor_1);  lightValue_2 = analogRead(lightSensor_2);  Serial.print("First Light Value: ");  Serial.println(lightValue_1);  Serial.print("Second Light Value: ");  Serial.println(lightValue_2);  servo_drive.write(120);  servo_steer.write(90);  delay(15);  if(lightValue_1 >= 900) {  /*servo_drive.write(60);    servo_steer.write(30);    delay(3000); */    ____________(right);  }    if(lightValue_2 >= 900) {  /*servo_drive.write(60);    servo_steer.write(150);    delay(3000); */    ____________(left);  }    if(lightValue_1 <= 50 && lightValue_2 <= 50) {  ____________();    }  delay(100);}void ____________(int direction) {  servo_drive.write(60);  delay(10);  servo_steer.write(______);  delay(3000);  servo_steer.write(90);  delay(10);}void ____________() {  servo_drive.write(______);  servo_steer.write(______);  delay(5000);}
+/*
+  CTC GO! MOTION 
+  PROJECT - Wiggler
+
+  This sketch is written to accompany Stage 5 of the Wiggler project
+*/
+
+#include <Servo.h>
+
+Servo servo_drive;
+Servo servo_steer;
+
+int lightSensor_1 = A0;
+int lightSensor_2 = A1;
+
+int lightValue_1 = 0;
+int lightValue_2 = 0;
+
+int ______ = 30;
+int ______ = 150;
+
+void setup() 
+{  
+  servo_steer.attach(6);
+  servo_drive.attach(9);
+  Serial.begin(9600);
+}
+
+void loop() 
+{
+  lightValue_1 = analogRead(lightSensor_1);
+  lightValue_2 = analogRead(lightSensor_2);
+
+  Serial.print("First Light Value: ");
+  Serial.println(lightValue_1);
+  Serial.print("Second Light Value: ");
+  Serial.println(lightValue_2);
+
+  servo_drive.write(120);
+  servo_steer.write(90);
+  delay(15);
+
+  if(lightValue_1 >= 900) {
+  /*servo_drive.write(60);
+    servo_steer.write(30);
+    delay(3000); */
+    ____________(right);
+  }
+  
+  if(lightValue_2 >= 900) {
+  /*servo_drive.write(60);
+    servo_steer.write(150);
+    delay(3000); */
+    ____________(left);
+  }
+  
+  if(lightValue_1 <= 50 && lightValue_2 <= 50) {
+  ____________();  
+  }
+
+  delay(100);
+}
+
+void ____________(int direction) {
+  servo_drive.write(60);
+  delay(10);
+  servo_steer.write(______);
+  delay(3000);
+  servo_steer.write(90);
+  delay(10);
+}
+
+void ____________() {
+  servo_drive.write(______);
+  servo_steer.write(______);
+  delay(5000);
+}
+
+


### PR DESCRIPTION
Previously, some of the example sketch files used "[CR](https://en.wikipedia.org/wiki/Carriage_return)" ("carriage return") [line endings](https://en.wikipedia.org/wiki/Newline).

This line ending was standard in the [classic "Mac OS" operating system](https://en.wikipedia.org/wiki/Classic_Mac_OS) (note this is different from the modern [macOS](https://en.wikipedia.org/wiki/MacOS)). Apple [switched to a POSIX-compliant operating system and "LF" ("line feed") line endings in 2001 with the release of OS X 10.0](https://en.wikipedia.org/wiki/Newline#Representation). Linux has always used "[LF](https://en.wikipedia.org/wiki/Line_feed)" line endings. Although Windows has historically used "CRLF" as the native line ending, "LF" is well supported (far more so than "CR"). For this reason, "LF" line endings are the standard for Arduino projects and software projects in general.

The use of the obsolete and non-standard "CR" line endings might cause difficulty for users working with the sketches in applications that don't have full support for "CR" line endings ([example](https://github.com/arduino-libraries/CTC-Go-Motions-Expansion/commit/85c10562ee29da82aeafea45079f071e007741ea#commitcomment-134605642)). It also might cause difficulties for contributors to the sketch code and for the project maintainers reviewing those contributions. For example, the GitHub web interface does not recognize these line endings and so displays the entire sketch as a single long line of code:

https://github.com/arduino-libraries/CTC-Go-Motions-Expansion/blob/4d5d89aee1fdf9dee7592a27173c2e351576de29/examples/Projects/SpinAWheel/spinAWheel_Stage1/spinAWheel_Stage1.ino

![image](https://github.com/arduino-libraries/CTC-Go-Motions-Expansion/assets/8572152/d49faa3f-dbdc-4b47-982b-02a8724e0fc1)

And the diff view for these files is quite unpleasant:

https://github.com/arduino-libraries/CTC-Go-Motions-Expansion/commit/85c10562ee29da82aeafea45079f071e007741ea#diff-e01fd5adba854647f0da888d7aa964859a29e502f2e75a31d02eb3e6e9b82ad7

![image](https://github.com/arduino-libraries/CTC-Go-Motions-Expansion/assets/8572152/662eba01-320e-4d77-aef6-1a958224fadd)

This pull request replaces the obsolete and inconsistent "CR" line endings with standard "LF" line endings.

---

Originally reported by @ElEstes at https://github.com/arduino-libraries/CTC-Go-Motions-Expansion/commit/85c10562ee29da82aeafea45079f071e007741ea#commitcomment-134605642